### PR TITLE
Do clang-tidy only on files from git diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 doc
 doxygen_warnings.txt
+.astyle_results.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,12 +108,12 @@ matrix:
     env:
       - TEST="Astyle Format"
     script:
-      - cmake ..
+      - cmake -DENABLE_ASTYLE=ON ..
       - make install
-      - bareflank_astyle_format.sh ..
+      - make format
       - |
         if [[ -n $(git diff) ]]; then
-          echo "You must run bareflank_astyle_format.sh before submitting a pull request"
+          echo "You must run make format before submitting a pull request"
           echo ""
           git diff
           exit -1
@@ -129,9 +129,10 @@ matrix:
       - |
         cmake \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DENABLE_TIDY=ON \
           ..
       - make install
-      - bareflank_clang_tidy.sh
+      - make tidy
 
   #
   # Codecov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 
 include("cmake/CMakeGlobal_Project.txt")
+include("cmake/CMakeOption_Tidy.txt")
+include("cmake/CMakeOption_Astyle.txt")
 
 # ------------------------------------------------------------------------------
 # JSON
@@ -228,9 +230,11 @@ install(FILES cmake/CMakeFlags_VMM.txt DESTINATION cmake)
 install(FILES cmake/CMakeGlobal_Includes.txt DESTINATION cmake)
 install(FILES cmake/CMakeGlobal_Project.txt DESTINATION cmake)
 install(FILES cmake/CMakeOption_ASan.txt DESTINATION cmake)
+install(FILES cmake/CMakeOption_Astyle.txt DESTINATION cmake)
 install(FILES cmake/CMakeOption_Coverage.txt DESTINATION cmake)
 install(FILES cmake/CMakeOption_Coverage_LLVM.txt DESTINATION cmake)
 install(FILES cmake/CMakeOption_Testing.txt DESTINATION cmake)
+install(FILES cmake/CMakeOption_Tidy.txt DESTINATION cmake)
 install(FILES cmake/CMakeOption_USan.txt DESTINATION cmake)
 install(FILES cmake/CMakeToolchain_VMM.txt DESTINATION cmake)
 install(FILES cmake/CMakeToolchain_VMM_38.txt DESTINATION cmake)

--- a/cmake/CMakeOption_Astyle.txt
+++ b/cmake/CMakeOption_Astyle.txt
@@ -1,0 +1,13 @@
+if (ENABLE_ASTYLE)
+
+    message("-- Code Formatting: Astyle")
+
+    add_custom_target(
+        format
+        COMMAND ${CMAKE_INSTALL_PREFIX}/bin/bareflank_astyle_format.sh
+        COMMENT "Running astyle format"
+        WORKING_DIRECTORY ../.
+        VERBATIM
+    )
+
+endif()

--- a/cmake/CMakeOption_Tidy.txt
+++ b/cmake/CMakeOption_Tidy.txt
@@ -1,0 +1,12 @@
+if(ENABLE_TIDY)
+
+    message("-- Static Analysis: Clang Tidy")
+
+    add_custom_target(
+        tidy
+        COMMAND ${CMAKE_INSTALL_PREFIX}/bin/bareflank_clang_tidy.sh
+        COMMENT "Running clang-tidy checks"
+        VERBATIM
+    )
+
+endif()

--- a/scripts/bareflank_astyle_format.sh
+++ b/scripts/bareflank_astyle_format.sh
@@ -20,6 +20,10 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+OUTPUT=$PWD/.astyle_results.txt
+
+rm -f $OUTPUT
+
 if [[ "$#" == 1 ]]; then
     cd $1
 fi
@@ -60,4 +64,14 @@ astyle \
     --close-templates \
     --add-brackets \
     --break-after-logical \
-    $FILES
+    $FILES > $OUTPUT
+
+if [[ -z $(grep -s Formatted $OUTPUT) ]]; then
+    echo -e "\xe2\x9c\x93 astyle passed"
+    exit
+else
+    echo -e "\xe2\x9c\x97 astyle failed: the following files were formatted:"
+    grep -s Formatted $OUTPUT | awk '{print $2}'
+    echo ""
+    exit -1
+fi


### PR DESCRIPTION
This patch adds two make targets:

    make tidy - performs clang-tidy checks on *staged* .cpp and .h files.
    make format - performs astyle formatting.

To enable the targets, include cmake/CMakeOption_Tidy.txt and
cmake/CMakeOption_Astyle.txt in your project and run cmake
with -DENABLE_TIDY=ON and -DENABLE_ASTYLE=ON