### PR TITLE
Add implied coverage flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,6 @@ matrix:
       - |
         cmake \
           -DENABLE_COVERAGE=ON \
-          -DENABLE_UNITTESTING \
           ..
       - make
       - make test
@@ -163,7 +162,7 @@ matrix:
           -DENABLE_COVERAGE_LLVM=ON \
           ..
       - make install
-      - bareflank_llvm_cov.sh
+      - make llvm_coverage
 
   #
   # Google Address Sanitizer

--- a/cmake/CMakeGlobal_Project.txt
+++ b/cmake/CMakeGlobal_Project.txt
@@ -142,6 +142,14 @@ message("-- Cross Compiler Sysroot: ${BAREFLANK_SYSROOT_PATH}")
 # Flag Information
 # ------------------------------------------------------------------------------
 
+if(ENABLE_COVERAGE_LLVM OR ENABLE_COVERAGE OR ENABLE_TIDY)
+    set(ENABLE_UNITTESTING ON)
+endif()
+
+if(ENABLE_TIDY)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 if(BAREFLANK_TOOLCHAIN_FLAGS)
     message("-- Flags: ${CMAKE_CURRENT_LIST_DIR}/${BAREFLANK_TOOLCHAIN_FLAGS}")
     include("${CMAKE_CURRENT_LIST_DIR}/${BAREFLANK_TOOLCHAIN_FLAGS}")

--- a/scripts/bareflank_clang_tidy.sh
+++ b/scripts/bareflank_clang_tidy.sh
@@ -45,6 +45,8 @@
 #
 OUTPUT=$PWD/.clang_tidy_results.txt
 
+CORES=$(grep -c ^processor /proc/cpuinfo)
+
 #
 # Make sure we can run this script
 #
@@ -98,6 +100,7 @@ get_changed_files() {
 run_clang_tidy() {
 
     run-clang-tidy-4.0.py \
+        -j $CORES \
         -clang-tidy-binary clang-tidy-4.0 \
         -header-filter=.* \
         -checks=$1 \


### PR DESCRIPTION
This commit sets ENABLE_UNITTESTING if ENABLE_COVERAGE
or ENABLE_COVERAGE_LLVM is set and sets
CMAKE_EXPORT_COMPILE_COMMANDS if ENABLE_TIDY is set.